### PR TITLE
Replace Argon2 with bcrypt for password hashing and update requirements

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -3,7 +3,7 @@ MongoDB database configuration and setup for Mergington High School API
 """
 
 from pymongo import MongoClient
-from argon2 import PasswordHasher
+import bcrypt
 
 # Connect to MongoDB
 client = MongoClient('mongodb://localhost:27017/')
@@ -13,9 +13,7 @@ teachers_collection = db['teachers']
 
 # Methods
 def hash_password(password):
-    """Hash password using Argon2"""
-    ph = PasswordHasher()
-    return ph.hash(password)
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 def init_database():
     """Initialize database if empty"""

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -15,6 +15,15 @@ teachers_collection = db['teachers']
 def hash_password(password):
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """
+    Verify a plain-text password against a stored bcrypt hash.
+
+    :param plain_password: The password provided by the user (plain text).
+    :param hashed_password: The bcrypt hash stored in the database.
+    :return: True if the password matches the hash, False otherwise.
+    """
+    return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
 def init_database():
     """Initialize database if empty"""
 

--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -13,6 +13,7 @@ teachers_collection = db['teachers']
 
 # Methods
 def hash_password(password):
+    """Hash a plain-text password and return a UTF-8 decoded bcrypt hash string."""
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.115.12
 uvicorn==0.34.2
 pymongo==4.12.1
-bcrypt>=4.0.0
+bcrypt==4.0.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,4 @@
 fastapi==0.115.12
 uvicorn==0.34.2
 pymongo==4.12.1
-argon2==0.1.10
-argon2-cffi==23.1.0
+bcrypt>=4.0.0


### PR DESCRIPTION
This pull request updates the password hashing implementation in the backend to use `bcrypt` instead of `argon2`. The changes affect both the code and dependencies to ensure consistent and secure password management.

**Password hashing implementation:**

* Replaced the use of `argon2` with `bcrypt` for password hashing in the `hash_password` function in `database.py`. (`src/backend/database.py`, [[1]](diffhunk://#diff-0fb71f0c3a6aa662719f0e4317d3215afcafc1a4753edf4021db3da7ea6d0d34L6-R6) [[2]](diffhunk://#diff-0fb71f0c3a6aa662719f0e4317d3215afcafc1a4753edf4021db3da7ea6d0d34L16-R16)

**Dependency updates:**

* Removed `argon2` and `argon2-cffi` from the requirements and added `bcrypt` as a dependency in `requirements.txt`. (`src/requirements.txt`, [src/requirements.txtL4-R4](diffhunk://#diff-0a0827574cc2d3aac80f74096dd6d1e871b83efae03aa087c2c8e8f1e9187d26L4-R4))